### PR TITLE
sepolicy: Treat proc-based DT fstab the same and sys-based

### DIFF
--- a/private/compat/26.0/26.0.ignore.cil
+++ b/private/compat/26.0/26.0.ignore.cil
@@ -86,6 +86,7 @@
     perfetto_traces_data_file
     perfprofd_service
     proc_cpu_alignment
+    proc_dt_firmware_android
     proc_last_kmsg
     proc_slabinfo
     property_info

--- a/private/compat/27.0/27.0.ignore.cil
+++ b/private/compat/27.0/27.0.ignore.cil
@@ -73,6 +73,7 @@
     perfetto_traces_data_file
     perfprofd_service
     proc_cpu_alignment
+    proc_dt_firmware_android
     proc_last_kmsg
     proc_slabinfo
     property_info

--- a/private/genfs_contexts
+++ b/private/genfs_contexts
@@ -7,6 +7,7 @@ genfscon proc /buddyinfo u:object_r:proc_buddyinfo:s0
 genfscon proc /cmdline u:object_r:proc_cmdline:s0
 genfscon proc /config.gz u:object_r:config_gz:s0
 genfscon proc /diskstats u:object_r:proc_diskstats:s0
+genfscon proc /device-tree/firmware/android u:object_r:proc_dt_firmware_android:s0
 genfscon proc /filesystems u:object_r:proc_filesystems:s0
 genfscon proc /interrupts u:object_r:proc_interrupts:s0
 genfscon proc /iomem u:object_r:proc_iomem:s0

--- a/public/file.te
+++ b/public/file.te
@@ -24,6 +24,7 @@ type proc_cpu_alignment, fs_type, proc_type;
 type proc_cpuinfo, fs_type, proc_type;
 type proc_dirty, fs_type, proc_type;
 type proc_diskstats, fs_type, proc_type;
+type proc_dt_firmware_android, fs_type, proc_type;
 type proc_extra_free_kbytes, fs_type, proc_type;
 type proc_filesystems, fs_type, proc_type;
 type proc_hostname, fs_type, proc_type;

--- a/public/init.te
+++ b/public/init.te
@@ -322,6 +322,7 @@ allow init {
 }:file w_file_perms;
 
 allow init {
+  proc_dt_firmware_android
   sysfs_dt_firmware_android
 }:file r_file_perms;
 

--- a/public/ueventd.te
+++ b/public/ueventd.te
@@ -24,6 +24,9 @@ allow ueventd self:netlink_kobject_uevent_socket create_socket_perms_no_ioctl;
 allow ueventd efs_file:dir search;
 allow ueventd efs_file:file r_file_perms;
 
+# Read the legacy DT fstab
+r_dir_file(ueventd, proc_dt_firmware_android)
+
 # Get SELinux enforcing status.
 r_dir_file(ueventd, selinuxfs)
 

--- a/public/uncrypt.te
+++ b/public/uncrypt.te
@@ -43,3 +43,6 @@ allow uncrypt proc_cmdline:file r_file_perms;
 
 # Read files in /sys
 r_dir_file(uncrypt, sysfs_dt_firmware_android)
+
+# Read files in /proc
+r_dir_file(uncrypt, proc_dt_firmware_android)

--- a/public/update_engine_common.te
+++ b/public/update_engine_common.te
@@ -43,3 +43,6 @@ allow update_engine_common proc_cmdline:file r_file_perms;
 
 # Read files in /sys/firmware/devicetree/base/firmware/android/
 r_dir_file(update_engine_common, sysfs_dt_firmware_android)
+
+# Read files in /proc/device-tree/firmware/android
+r_dir_file(update_engine_common, proc_dt_firmware_android)

--- a/public/vold.te
+++ b/public/vold.te
@@ -16,6 +16,9 @@ allow vold sysfs_dm:file w_file_perms;
 allow vold sysfs_usb:file w_file_perms;
 allow vold sysfs_zram_uevent:file w_file_perms;
 
+# Read the legacy DT fstab
+r_dir_file(vold, proc_dt_firmware_android)
+
 r_dir_file(vold, rootfs)
 r_dir_file(vold, metadata_file)
 allow vold {


### PR DESCRIPTION
* Older devices have a DT fstab in proc, so we need to expand our
  policy to make this first-class like the fancy, new, sys devices

Change-Id: I3cfed1e8e9fdf8665f1348fa07fa42d4f37873e9